### PR TITLE
Don't require a 'ignore' key in IMAGO_BOUNDARY_MAPPINGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Imago's `loadmappings` management command loads mappings between divisions manag
 * Set `IMAGO_BOUNDARY_MAPPINGS` in `settings.py`, a dictionary in which each key is the slug of a boundary set and each value is a dictionary, which has as keys:
   * `key`: The property of a division identifier that will be used to match a boundary's `external_id`.
   * `prefix`: Imago will prepend this prefix to a boundary's `external_id`, and will look for a division identifier whose property, identified by `key`, matches.
-  * `ignore`: Either `None` or a regular expression string. If no match is found, and if either `ignore` is `None` or the boundary name doesn't match the regular expression, a warning will be issued about the unmatched `external_id`.
-  * `start`: Ignored. This functionality has been moved into [Represent Boundaries](http://represent.poplus.org/).
+  * `ignore`: Optional. A regular expression string. If no match is found, and if either `ignore` is missing or the boundary name doesn't match the regular expression, a warning will be issued about the unmatched `external_id`.
 
 See [api.opencivicdata.org's `settings.py`](https://github.com/opencivicdata/api.opencivicdata.org/blob/master/ocdapi/settings.py#L132) for an example.

--- a/imago/management/commands/loadmappings.py
+++ b/imago/management/commands/loadmappings.py
@@ -11,7 +11,7 @@ from opencivicdata.divisions import Division
 from boundaries.models import BoundarySet
 
 
-def load_mapping(boundary_set_id, start, key, prefix, ignore, end=None, quiet=False):
+def load_mapping(boundary_set_id, key, prefix, ignore=None, end=None, quiet=False, **kwargs):
     if ignore:
         ignore = re.compile(ignore)
     ignored = 0


### PR DESCRIPTION
I also removed the obsolete `start` key from the method's arguments, but allowed it to pass through as `**kwargs` to avoid breaking backwards compatibility (with api.opencivicdata.org notably).