### PR TITLE
Allow using any boundary property for matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Imago's `loadmappings` management command loads mappings between divisions manag
 
 * Set `IMAGO_COUNTRY` to a two-letter, lowercase country code like `'us'` in `settings.py`, to select which country's [Open Civic Data Division Identifiers](http://docs.opencivicdata.org/en/latest/proposals/0002.html) to use.
 * Set `IMAGO_BOUNDARY_MAPPINGS` in `settings.py`, a dictionary in which each key is the slug of a boundary set and each value is a dictionary, which has as keys:
-  * `key`: The property of a division identifier that will be used to match a boundary's `external_id`.
-  * `prefix`: Imago will prepend this prefix to a boundary's `external_id`, and will look for a division identifier whose property, identified by `key`, matches.
-  * `ignore`: Optional. A regular expression string. If no match is found, and if either `ignore` is missing or the boundary name doesn't match the regular expression, a warning will be issued about the unmatched `external_id`.
+  * `key`: The property of a division identifier that will be used for matching.
+  * `boundary_key`: Optional. Defaults to `external_id`. The property of a boundary that will be used for matching.
+  * `prefix`: Imago will prepend this prefix to the property of the boundary, identified by `boundary_key`, and will look for the division identifier whose property, identified by `key`, matches.
+  * `ignore`: Optional. A regular expression string. If no match is found, and if either `ignore` is missing or the boundary name doesn't match the regular expression, a warning will be issued about the unmatched boundary.
 
 See [api.opencivicdata.org's `settings.py`](https://github.com/opencivicdata/api.opencivicdata.org/blob/master/ocdapi/settings.py#L132) for an example.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Imago's `loadmappings` management command loads mappings between divisions manag
 * Set `IMAGO_BOUNDARY_MAPPINGS` in `settings.py`, a dictionary in which each key is the slug of a boundary set and each value is a dictionary, which has as keys:
   * `key`: The property of a division identifier that will be used to match a boundary's `external_id`.
   * `prefix`: Imago will prepend this prefix to a boundary's `external_id`, and will look for a division identifier whose property, identified by `key`, matches.
-  * `ignore`: Either `None` or a regular expression string. If no match is found, and if either `ignore` is `None` or the boundary name doesn't match the regular expression, a warning will be issued about the unmatched `external_id`.
-  * `start`: Ignored. This functionality has been moved into [Represent Boundaries](http://represent.poplus.org/).
+  * `ignore`: Optional. A regular expression string. If no match is found, and if either `ignore` is missing or the boundary name doesn't match the regular expression, a warning will be issued about the unmatched `external_id`.
 
 See [api.opencivicdata.org's `settings.py`](https://github.com/opencivicdata/api.opencivicdata.org/blob/master/ocdapi/settings.py#L132) for an example.

--- a/imago/management/commands/loadmappings.py
+++ b/imago/management/commands/loadmappings.py
@@ -11,7 +11,7 @@ from opencivicdata.divisions import Division
 from boundaries.models import BoundarySet
 
 
-def load_mapping(boundary_set_id, key, prefix, ignore=None, end=None, quiet=False, **kwargs):
+def load_mapping(boundary_set_id, key, prefix, boundary_key='external_id', ignore=None, end=None, quiet=False, **kwargs):
     if ignore:
         ignore = re.compile(ignore)
     ignored = 0
@@ -26,14 +26,14 @@ def load_mapping(boundary_set_id, key, prefix, ignore=None, end=None, quiet=Fals
     print('processing', boundary_set_id)
 
     boundary_set = BoundarySet.objects.get(pk=boundary_set_id)
-    for boundary in boundary_set.boundaries.values('external_id', 'id', 'name'):
-        ocd_id = geoid_mapping.get(prefix+boundary['external_id'])
+    for boundary in boundary_set.boundaries.values(boundary_key, 'id', 'name'):
+        ocd_id = geoid_mapping.get(prefix+boundary[boundary_key])
         if ocd_id:
             division_geometries.append(DivisionGeometry(division_id=ocd_id,
                                                         boundary_id=boundary['id']))
         elif not ignore or not ignore.match(boundary['name']):
             if not quiet:
-                print('unmatched external id', boundary['name'], boundary['external_id'])
+                print('unmatched external id', boundary['name'], boundary[boundary_key])
         else:
             ignored += 1
 

--- a/imago/management/commands/loadmappings.py
+++ b/imago/management/commands/loadmappings.py
@@ -11,7 +11,7 @@ from opencivicdata.divisions import Division
 from boundaries.models import BoundarySet
 
 
-def load_mapping(boundary_set_id, start, key, prefix, ignore, end=None, quiet=False):
+def load_mapping(boundary_set_id, key, prefix, ignore=None, end=None, quiet=False, **kwargs):
     if ignore:
         ignore = re.compile(ignore)
     ignored = 0


### PR DESCRIPTION
Includes #40. I don't have an `external_id` set on all boundaries.