### PR TITLE
Add a missing comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='imago',
           ]
       },
       install_requires=[
-          'pytz'
+          'pytz',
           'pyelasticsearch>=0.6',
           'Django>=1.6',
           'opencivicdata-django>=0.6.2',


### PR DESCRIPTION
Small PR to fix the error "Could not find a version that satisfies the requirement pytzpyelasticsearch>=0.6".

Quite a weird package name!