### PR TITLE
show related entities of bill actions

### DIFF
--- a/imago/serialize.py
+++ b/imago/serialize.py
@@ -257,7 +257,10 @@ BILL_SERIALIZE = dict([
 
     ('actions', {'organization': ORGANIZATION_SERIALIZE, 'description': {},
                  'date': {}, 'classification': lambda x: x.classification,
-                 'order': {}}),
+                 'order': {}, 
+                 'related_entities' : {'name' : {}, 'entity_type' : {},
+                                       'organization_id' : {}, 
+                                       'person_id' : {}}}),
 
     ('sponsorships', {"primary": {}, "classification": {}, "entity_name": {},
                       "entity_type": {}, "entity_id": {}}),

--- a/imago/views.py
+++ b/imago/views.py
@@ -236,6 +236,10 @@ class BillDetail(PublicDetailEndpoint):
         'actions.classification',
         'actions.organization.id',
         'actions.organization.name',
+        'actions.related_entities.name',
+        'actions.related_entities.organization_id',
+        'actions.related_entities.person_id',
+        'actions.related_entities.entity_type',
 
         'votes.result',
         'votes.motion_text',


### PR DESCRIPTION
This PR updates the Bill Detail view to show related entities to a bill action. We need this for municipal scrapers so we can track which committee has current control of a bill see https://github.com/opencivicdata/scrapers-us-municipal/issues/46#issuecomment-107647420