### PR TITLE
expose division_ids in posts listing

### DIFF
--- a/imago/serialize.py
+++ b/imago/serialize.py
@@ -180,6 +180,7 @@ POST_SERIALIZE = dict([
     ("contact_details", CONTACT_DETAIL_SERIALIZE),
     ("organization", ORGANIZATION_SERIALIZE),
     ("division", DIVISION_SERIALIZE),
+    ("division_id", {}),
 ])
 
 

--- a/imago/views.py
+++ b/imago/views.py
@@ -100,6 +100,7 @@ class OrganizationDetail(PublicDetailEndpoint):
 
         'posts.id',
         'posts.label',
+        'posts.division.id',
         'posts.role',
     ]
 

--- a/imago/views.py
+++ b/imago/views.py
@@ -100,7 +100,7 @@ class OrganizationDetail(PublicDetailEndpoint):
 
         'posts.id',
         'posts.label',
-        'posts.division.id',
+        'posts.division_id',
         'posts.role',
     ]
 


### PR DESCRIPTION
Show division ids in listings of posts within an organizations. Allows us to walk from person --> post --> division --> geography 