### PR TITLE
lists posts associated with a division

### DIFF
--- a/imago/serialize.py
+++ b/imago/serialize.py
@@ -372,5 +372,6 @@ DIVISION_SERIALIZE = {
     'children': lambda division: [{'id': d.id, 'name': d.name}
                                    for d in Division.objects.children_of(division.id)],
     'geometries': lambda division: [boundary_to_dict(dg.boundary)
-                                    for dg in division.geometries.all()]
+                                    for dg in division.geometries.all()],
+    'posts' : POST_SERIALIZE
 }

--- a/imago/views.py
+++ b/imago/views.py
@@ -324,5 +324,6 @@ class DivisionDetail(PublicDetailEndpoint):
                       'posts.id',
                       'posts.organization.id',
                       'posts.organization.name',
+                      'posts.organization.classification',
                       'posts.label',
                       'posts.role']

--- a/imago/views.py
+++ b/imago/views.py
@@ -315,4 +315,14 @@ class DivisionList(PublicListEndpoint):
 class DivisionDetail(PublicDetailEndpoint):
     model = Division
     serialize_config = DIVISION_SERIALIZE
-    default_fields = ['id', 'name', 'country', 'jurisdictions', 'children', 'geometries']
+    default_fields = ['id', 
+                      'name', 
+                      'country', 
+                      'jurisdictions', 
+                      'children', 
+                      'geometries',
+                      'posts.id',
+                      'posts.organization.id',
+                      'posts.organization.name',
+                      'posts.label',
+                      'posts.role']


### PR DESCRIPTION
On division detail pages, list associated posts, with their relevant organizations.