### PR TITLE
Event media links should be serialized with LINK_BASE

### DIFF
--- a/imago/serialize.py
+++ b/imago/serialize.py
@@ -85,10 +85,11 @@ CONTACT_DETAIL_SERIALIZE = dict([("type", {}), ("value", {}),
                                  ("note", {}), ("label", {})])
 
 
-LINK_SERALIZE = dict([
+LINK_SERIALIZE = dict([
     ("note", {}),
     ("url", {}),
 ])
+
 
 
 IDENTIFIERS_SERIALIZE = {
@@ -116,7 +117,7 @@ ORGANIZATION_SERIALIZE = dict([
     ("extras", lambda x: x.extras),
 
     ("identifiers", IDENTIFIERS_SERIALIZE),
-    ("links", LINK_SERALIZE),
+    ("links", LINK_SERIALIZE),
     ("contact_details", CONTACT_DETAIL_SERIALIZE),
     ("other_names", OTHER_NAMES_SERIALIZE),
     ("classification", {}),
@@ -165,7 +166,7 @@ PERSON_SERIALIZE = dict([
     ("identifiers", IDENTIFIERS_SERIALIZE),
     ("other_names", OTHER_NAMES_SERIALIZE),
     ("contact_details", CONTACT_DETAIL_SERIALIZE),
-    ("links", LINK_SERALIZE),
+    ("links", LINK_SERIALIZE),
     ("sources", SOURCES_SERIALIZE),
 ])
 
@@ -176,7 +177,7 @@ POST_SERIALIZE = dict([
     ("role", {}),
     ("start_date", {}),
     ("end_date", {}),
-    ("links", LINK_SERALIZE),
+    ("links", LINK_SERIALIZE),
     ("contact_details", CONTACT_DETAIL_SERIALIZE),
     ("organization", ORGANIZATION_SERIALIZE),
     ("division", DIVISION_SERIALIZE),
@@ -334,9 +335,9 @@ EVENT_SERIALIZE = dict([
                       "entity_id": {}}),
 
     ('documents', {"note": {}, "date": {}, "links": LINK_BASE}),
-    ('media', {"note": {}, "date": {}, "offset": {}, "links": LINK_SERALIZE}),
+    ('media', {"note": {}, "date": {}, "offset": {}, "links": LINK_BASE}),
 
-    ("links", LINK_SERALIZE),
+    ("links", LINK_SERIALIZE),
 
     ('created_at', {}),
     ('updated_at', {}),


### PR DESCRIPTION
The wrong kind of link serializer was being used for event media links.