### PR TITLE
Fix "get_all_field_names is an unofficial API that has been deprecated"

### DIFF
--- a/imago/helpers.py
+++ b/imago/helpers.py
@@ -26,7 +26,7 @@ def get_field_list(model, without=None):
         without = set()
     else:
         without = set(without)
-    return list(set(model._meta.get_all_field_names()) - without)
+    return list({f.name for f in model._meta.get_fields()} - without)
 
 
 class FieldKeyError(KeyError):


### PR DESCRIPTION
The [docs](https://docs.djangoproject.com/en/1.8/ref/models/meta/) also list a more complex replacement:

```python
from itertools import chain
list(set(chain.from_iterable(
    (field.name, field.attname) if hasattr(field, 'attname') else (field.name,)
    for field in MyModel._meta.get_fields()
    # For complete backwards compatibility, you may want to exclude
    # GenericForeignKey from the results.
    if not (field.many_to_one and field.related_model is None)
)))
```