### PR TITLE
don't show agendas in event list, too expensive

### DIFF
--- a/imago/views.py
+++ b/imago/views.py
@@ -269,12 +269,6 @@ class EventList(PublicListEndpoint):
     default_fields = [
         'id', 'name', 'description', 'classification', 'start_time',
         'timezone', 'end_time', 'all_day', 'status',
-
-        'agenda.description', 'agenda.order', 'agenda.subjects',
-        'agenda.related_entities.note',
-        'agenda.related_entities.entity_name',
-        'agenda.related_entities.entity_id',
-        'agenda.related_entities.entity_type',
     ]
 
 


### PR DESCRIPTION
In Chicago, we have agendas that can contain thousands of items. Including agendas in the event list was making this event page take almost a minute to load.