### PR TITLE
Convert datetimes with an existing timezone to UTC

### DIFF
--- a/imago/serialize.py
+++ b/imago/serialize.py
@@ -31,6 +31,8 @@ def dout(obj):
     """
     if obj is None:
         return
+    if obj.tzinfo:
+        return obj.astimezone(pytz.UTC).isoformat()
     return pytz.UTC.localize(obj).isoformat()
 
 


### PR DESCRIPTION
`datetime` objects already stored with timezones were causing `dout` to fail. `localize` should only be used on naive `datetime` values. This uses `astimezone` for timezone-aware objects.